### PR TITLE
Remove a workaround for the conflict of the name of the modules

### DIFF
--- a/onlinejudge_command/download_history.py
+++ b/onlinejudge_command/download_history.py
@@ -7,7 +7,8 @@ from typing import *
 
 import onlinejudge_command.logging as log
 import onlinejudge_command.utils as utils
-from onlinejudge_workaround_for_conflict.type import Problem
+
+from onlinejudge.type import Problem
 
 
 class DownloadHistory(object):

--- a/onlinejudge_command/main.py
+++ b/onlinejudge_command/main.py
@@ -10,7 +10,6 @@ import onlinejudge_command.__about__ as version
 import onlinejudge_command.logging as log
 import onlinejudge_command.update_checking as update_checking
 import onlinejudge_command.utils as utils
-import onlinejudge_workaround_for_conflict.__about__ as api_version  # see https://github.com/online-judge-tools/oj/issues/755#issuecomment-623118672
 from onlinejudge_command.subcommand.download import download
 from onlinejudge_command.subcommand.generate_input import generate_input
 from onlinejudge_command.subcommand.generate_output import generate_output
@@ -18,6 +17,8 @@ from onlinejudge_command.subcommand.login import login
 from onlinejudge_command.subcommand.submit import submit
 from onlinejudge_command.subcommand.test import test
 from onlinejudge_command.subcommand.test_reactive import test_reactive
+
+import onlinejudge.__about__ as api_version
 
 
 def get_parser() -> argparse.ArgumentParser:

--- a/onlinejudge_command/subcommand/download.py
+++ b/onlinejudge_command/subcommand/download.py
@@ -8,10 +8,11 @@ import onlinejudge_command.download_history
 import onlinejudge_command.format_utils as format_utils
 import onlinejudge_command.logging as log
 import onlinejudge_command.utils as utils
-import onlinejudge_workaround_for_conflict.dispatch as dispatch  # see https://github.com/online-judge-tools/oj/issues/755#issuecomment-623118672
 import requests.exceptions
-from onlinejudge_workaround_for_conflict.service.yukicoder import YukicoderProblem  # see https://github.com/online-judge-tools/oj/issues/755#issuecomment-623118672
-from onlinejudge_workaround_for_conflict.type import SampleParseError, TestCase  # see https://github.com/online-judge-tools/oj/issues/755#issuecomment-623118672
+
+import onlinejudge.dispatch as dispatch
+from onlinejudge.service.yukicoder import YukicoderProblem
+from onlinejudge.type import SampleParseError, TestCase
 
 if TYPE_CHECKING:
     import argparse

--- a/onlinejudge_command/subcommand/login.py
+++ b/onlinejudge_command/subcommand/login.py
@@ -8,9 +8,10 @@ from typing import *
 
 import onlinejudge_command.logging as log
 import onlinejudge_command.utils as utils
-import onlinejudge_workaround_for_conflict.dispatch as dispatch  # see https://github.com/online-judge-tools/oj/issues/755#issuecomment-623118672
 import requests
-from onlinejudge_workaround_for_conflict.type import LoginError, Service  # see https://github.com/online-judge-tools/oj/issues/755#issuecomment-623118672
+
+import onlinejudge.dispatch as dispatch
+from onlinejudge.type import LoginError, Service
 
 if TYPE_CHECKING:
     import argparse

--- a/onlinejudge_command/subcommand/submit.py
+++ b/onlinejudge_command/subcommand/submit.py
@@ -9,8 +9,9 @@ from typing import *
 import onlinejudge_command.download_history
 import onlinejudge_command.logging as log
 import onlinejudge_command.utils as utils
-import onlinejudge_workaround_for_conflict.dispatch as dispatch  # see https://github.com/online-judge-tools/oj/issues/755#issuecomment-623118672
-from onlinejudge_workaround_for_conflict.type import *  # see https://github.com/online-judge-tools/oj/issues/755#issuecomment-623118672
+
+import onlinejudge.dispatch as dispatch
+from onlinejudge.type import *
 
 if TYPE_CHECKING:
     import argparse

--- a/onlinejudge_command/update_checking.py
+++ b/onlinejudge_command/update_checking.py
@@ -6,9 +6,10 @@ from typing import *
 
 import onlinejudge_command.__about__ as version
 import onlinejudge_command.logging as log
-import onlinejudge_workaround_for_conflict.__about__ as api_version
 import requests
-from onlinejudge_workaround_for_conflict.utils import user_cache_dir
+
+import onlinejudge.__about__ as api_version
+from onlinejudge.utils import user_cache_dir
 
 
 def describe_status_code(status_code: int) -> str:

--- a/onlinejudge_command/utils.py
+++ b/onlinejudge_command/utils.py
@@ -16,9 +16,10 @@ from typing.io import *
 
 import onlinejudge_command.__about__ as version
 import onlinejudge_command.logging as log
-import onlinejudge_workaround_for_conflict.utils as utils
 import requests
-from onlinejudge_workaround_for_conflict.type import *
+
+import onlinejudge.utils as utils
+from onlinejudge.type import *
 
 user_data_dir = utils.user_data_dir
 user_cache_dir = utils.user_cache_dir

--- a/tests/command_download.py
+++ b/tests/command_download.py
@@ -6,7 +6,8 @@ import requests.exceptions
 import tests.utils
 from onlinejudge_command.main import get_parser
 from onlinejudge_command.subcommand.download import download
-from onlinejudge_workaround_for_conflict.type import SampleParseError
+
+from onlinejudge.type import SampleParseError
 
 
 def get_files_from_json(samples):

--- a/tests/command_download_invalid.py
+++ b/tests/command_download_invalid.py
@@ -2,7 +2,8 @@ import unittest
 
 import requests.exceptions
 import tests.command_download
-from onlinejudge_workaround_for_conflict.type import SampleParseError
+
+from onlinejudge.type import SampleParseError
 
 
 class DownloadInvalidTest(unittest.TestCase):

--- a/tests/command_login.py
+++ b/tests/command_login.py
@@ -1,11 +1,12 @@
 import unittest
 
 import tests.utils
-from onlinejudge_workaround_for_conflict.service.atcoder import AtCoderService
-from onlinejudge_workaround_for_conflict.service.codeforces import CodeforcesService
-from onlinejudge_workaround_for_conflict.service.hackerrank import HackerRankService
-from onlinejudge_workaround_for_conflict.service.toph import TophService
-from onlinejudge_workaround_for_conflict.service.yukicoder import YukicoderService
+
+from onlinejudge.service.atcoder import AtCoderService
+from onlinejudge.service.codeforces import CodeforcesService
+from onlinejudge.service.hackerrank import HackerRankService
+from onlinejudge.service.toph import TophService
+from onlinejudge.service.yukicoder import YukicoderService
 
 
 class LoginTest(unittest.TestCase):

--- a/tests/command_submit.py
+++ b/tests/command_submit.py
@@ -7,11 +7,12 @@ import requests.exceptions
 import tests.utils
 from onlinejudge_command.main import get_parser
 from onlinejudge_command.subcommand.submit import submit
-from onlinejudge_workaround_for_conflict.service.atcoder import AtCoderService
-from onlinejudge_workaround_for_conflict.service.codeforces import CodeforcesService
-from onlinejudge_workaround_for_conflict.service.hackerrank import HackerRankService
-from onlinejudge_workaround_for_conflict.service.toph import TophService
-from onlinejudge_workaround_for_conflict.service.yukicoder import YukicoderService
+
+from onlinejudge.service.atcoder import AtCoderService
+from onlinejudge.service.codeforces import CodeforcesService
+from onlinejudge.service.hackerrank import HackerRankService
+from onlinejudge.service.toph import TophService
+from onlinejudge.service.yukicoder import YukicoderService
 
 
 class SubmitArgumentsTest(unittest.TestCase):

--- a/tests/implementation_language_guessing.py
+++ b/tests/implementation_language_guessing.py
@@ -3,7 +3,8 @@ import textwrap
 import unittest
 
 import onlinejudge_command.subcommand.submit as submit
-from onlinejudge_workaround_for_conflict.type import Language, LanguageId
+
+from onlinejudge.type import Language, LanguageId
 
 # https://atcoder.jp/contests/language-test-ver1
 languages_atcoder_3 = [


### PR DESCRIPTION
see https://github.com/online-judge-tools/oj/issues/755#issuecomment-623118672

It has passed enough time from the version 10.0.0 and the effect of
the conflict becomes little. It's time to remove this workaround.