### PR TITLE
Use explorer.exe on WSL

### DIFF
--- a/onlinejudge_command/subcommand/submit.py
+++ b/onlinejudge_command/subcommand/submit.py
@@ -135,11 +135,17 @@ def submit(args: 'argparse.Namespace') -> None:
 
         # show result
         if args.open:
-            browser = webbrowser.get()
-            log.status('open the submission page with browser')
-            opened = browser.open_new_tab(submission.get_url())
-            if not opened:
-                log.failure('failed to open the url. please set the $BROWSER envvar')
+            utils.webbrowser_register_explorer_exe()
+            try:
+                browser = webbrowser.get(using='nomomo')
+            except webbrowser.Error as e:
+                log.error('%s', e)
+                log.info('please set the $BROWSER envvar')
+            else:
+                log.status('open the submission page with browser: %s', browser)
+                opened = browser.open_new_tab(submission.get_url())
+                if not opened:
+                    log.failure('failed to open the url. please set the $BROWSER envvar')
 
 
 def select_ids_of_matched_languages(words: List[str], lang_ids: List[str], language_dict, split: bool = False, remove: bool = False) -> List[str]:

--- a/onlinejudge_command/subcommand/submit.py
+++ b/onlinejudge_command/subcommand/submit.py
@@ -137,7 +137,7 @@ def submit(args: 'argparse.Namespace') -> None:
         if args.open:
             utils.webbrowser_register_explorer_exe()
             try:
-                browser = webbrowser.get(using='nomomo')
+                browser = webbrowser.get()
             except webbrowser.Error as e:
                 log.error('%s', e)
                 log.info('please set the $BROWSER envvar')

--- a/onlinejudge_command/subcommand/submit.py
+++ b/onlinejudge_command/subcommand/submit.py
@@ -143,9 +143,7 @@ def submit(args: 'argparse.Namespace') -> None:
                 log.info('please set the $BROWSER envvar')
             else:
                 log.status('open the submission page with browser: %s', browser)
-                opened = browser.open_new_tab(submission.get_url())
-                if not opened:
-                    log.failure('failed to open the url. please set the $BROWSER envvar')
+                browser.open_new_tab(submission.get_url())
 
 
 def select_ids_of_matched_languages(words: List[str], lang_ids: List[str], language_dict, split: bool = False, remove: bool = False) -> List[str]:

--- a/onlinejudge_command/utils.py
+++ b/onlinejudge_command/utils.py
@@ -183,5 +183,5 @@ def webbrowser_register_explorer_exe() -> None:
 
     if not is_windows_subsystem_for_linux():
         return
-    instance = webbrowser.BackgroundBrowser('explorer.exe')
+    instance = webbrowser.GenericBrowser('explorer.exe')
     webbrowser.register('explorer', None, instance)

--- a/onlinejudge_command/utils.py
+++ b/onlinejudge_command/utils.py
@@ -1,8 +1,10 @@
 # Python Version: 3.x
 import contextlib
 import datetime
+import functools
 import os
 import pathlib
+import platform
 import re
 import shlex
 import shutil
@@ -11,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import webbrowser
 from typing import *
 from typing.io import *
 
@@ -165,3 +168,20 @@ def make_pretty_large_file_content(content: bytes, limit: int, head: int, tail: 
     candidates += snip_line_based()
     candidates += snip_char_based()
     return min(candidates, key=len)
+
+
+def is_windows_subsystem_for_linux() -> bool:
+    return platform.uname().system == 'Linux' and 'Microsoft' in platform.uname().release
+
+
+@functools.lru_cache(maxsize=None)
+def webbrowser_register_explorer_exe() -> None:
+    """webbrowser_register_explorer registers `explorer.exe` in the list of browsers under Windows Subsystem for Linux.
+
+    See https://github.com/online-judge-tools/oj/issues/773
+    """
+
+    if not is_windows_subsystem_for_linux():
+        return
+    instance = webbrowser.BackgroundBrowser('explorer.exe')
+    webbrowser.register('explorer', None, instance)

--- a/onlinejudge_command/utils.py
+++ b/onlinejudge_command/utils.py
@@ -181,7 +181,11 @@ def webbrowser_register_explorer_exe() -> None:
     See https://github.com/online-judge-tools/oj/issues/773
     """
 
+    # There is an issue that the terminal is cleared after `.open_new_tab()`. The reason is unknown, but adding an argurment `preferred=True` to `webbrowser.register` resolves this issues.
+
+    # See https://github.com/online-judge-tools/oj/pull/784
+
     if not is_windows_subsystem_for_linux():
         return
     instance = webbrowser.GenericBrowser('explorer.exe')
-    webbrowser.register('explorer', None, instance)
+    webbrowser.register('explorer', None, instance)  # TODO: use `preferred=True` to solve the issue that terminal is cleared, when the version of Python becomes 3.7 or higher


### PR DESCRIPTION
fix https://github.com/online-judge-tools/oj/issues/773

このプルリクは、WSL 内で `oj s` するとウェブブラウザが起動してくれない問題を修正します。
Windows 環境がないのでテストができていません。以下 2 点を誰かが手動で確認して報告してくれたらマージします。

- 環境変数 `BROWSER` を設定しない状態で WSL 内側で `oj s` をすると Windows 側で何らかのウェブブラウザが起動する
- 環境変数 `BROWSER` を設定した状態で WSL 内側で `oj s` をすると Windows 側で `BROWSER` で指定したものと同じウェブブラウザが起動する

よろしくお願いします。