### PR TITLE
Fix the bug of generate-input subcommand which happens when generatrs failed

### DIFF
--- a/onlinejudge_command/subcommand/generate_input.py
+++ b/onlinejudge_command/subcommand/generate_input.py
@@ -5,6 +5,7 @@ import contextlib
 import itertools
 import os
 import pathlib
+import subprocess
 import threading
 from logging import getLogger
 from typing import *
@@ -59,14 +60,14 @@ def write_result(input_data: bytes, output_data: Optional[bytes], *, input_path:
             logger.info(utils.SUCCESS + 'saved to: %s', output_path)
 
 
-def check_status(info, proc, *, submit):
+def check_status(info: Dict[str, Any], proc: subprocess.Popen, *, submit: Callable[..., None]) -> bool:
     submit(logger.info, 'time: %f sec', info['elapsed'])
     if proc.returncode is None:
-        submit(logger.failure, logger.red('TLE'))
+        submit(logger.info, utils.FAILURE + utils.red('TLE'))
         submit(logger.info, 'skipped.')
         return False
     elif proc.returncode != 0:
-        submit(logger.failure, logger.red('RE') + ': return code %d', proc.returncode)
+        submit(logger.info, utils.FAILURE + utils.red('RE') + ': return code %d', proc.returncode)
         submit(logger.info, 'skipped.')
         return False
     assert info['answer'] is not None

--- a/tests/command_generate_input.py
+++ b/tests/command_generate_input.py
@@ -113,3 +113,16 @@ class GenerateInputTest(unittest.TestCase):
                 'data': '1\n'
             },
         ])
+
+    def test_call_generate_input_failure(self):
+        self.snippet_call_generate_input(
+            args=[tests.utils.python_script('generate.py'), '3'],
+            input_files=[
+                {
+                    'path': 'generate.py',
+                    'data': 'raise RuntimeError()\n'
+                },
+            ],
+            expected_values=[],
+            disallowed_files=['test/random-{}.in'.format(str(i).zfill(3)) for i in range(3)],
+        )


### PR DESCRIPTION
#806 を確認してたら気付けた

関数に型ヒントがないとその内部の型検査が省略されてしまうんですが、「mypy さんは良いっていってるし動くでしょ」をしてるとこういうところでやられる。
あとそもそもテストを書いてないのがだめ。コーナーケースでもきっちり書きましょう。