### PR TITLE
[breaking changes] Modify the ways of comparing outputs in `test` subcommand

### DIFF
--- a/onlinejudge_command/main.py
+++ b/onlinejudge_command/main.py
@@ -17,7 +17,7 @@ from onlinejudge_command.subcommand.generate_input import generate_input
 from onlinejudge_command.subcommand.generate_output import generate_output
 from onlinejudge_command.subcommand.login import login
 from onlinejudge_command.subcommand.submit import submit
-from onlinejudge_command.subcommand.test import test
+from onlinejudge_command.subcommand.test import CompareMode, DisplayMode, test
 from onlinejudge_command.subcommand.test_reactive import test_reactive
 
 import onlinejudge.__about__ as api_version
@@ -128,10 +128,11 @@ tips:
     subparser.add_argument('-c', '--command', default='./a.out', help='your solution to be tested. (default: "./a.out")')
     subparser.add_argument('-f', '--format', default='%s.%e', help='a format string to recognize the relationship of test cases. (default: "%%s.%%e")')
     subparser.add_argument('-d', '--directory', type=pathlib.Path, default=pathlib.Path('test'), help='a directory name for test cases (default: test/)')
-    subparser.add_argument('-m', '--display-mode', choices=['simple', 'side-by-side'], default='simple', help='mode to display an output with the correct answer (default: simple)')
-    subparser.add_argument('-S', '--side-by-side', dest='display_mode', action='store_const', const='side-by-side', help='display an output and the correct answer with side by side mode (equivalent to --display-mode side-by-side)')
-    subparser.add_argument('--no-rstrip', action='store_false', dest='rstrip')
-    subparser.add_argument('--rstrip', action='store_true', help='rstrip output before compare (default)')
+    subparser.add_argument('-m', '--compare-mode', choices=[mode.value for mode in CompareMode], default=CompareMode.CRLF_INSENSITIVE_EXACT_MATCH.value, help='mode to compare outputs. The default behavoir is exact-match to ensure that you always get AC on remote judge servers when you got AC on local tests for the same cases.  (default: crlf-insensitive-exact-match)')
+    subparser.add_argument('-M', '--display-mode', choices=[mode.value for mode in DisplayMode], default=DisplayMode.SUMMARY.value, help='mode to display outputs  (default: summary)')
+    subparser.add_argument('-S', '--ignore-spaces', dest='compare_mode', action='store_const', const=CompareMode.IGNORE_SPACES.value, help="ignore spaces to compare outputs, but doesn't ignore newlines  (equivalent to --compare-mode=ignore-spaces")
+    subparser.add_argument('-N', '--ignore-spaces-and-newlines', dest='compare_mode', action='store_const', const=CompareMode.IGNORE_SPACES_AND_NEWLINES.value, help='ignore spaces and newlines to compare outputs  (equivalent to --compare-mode=ignore-spaces-and-newlines')
+    subparser.add_argument('-D', '--diff', dest='display_mode', action='store_const', const=DisplayMode.DIFF.value, help='display the diff  (equivalent to --display-mode=diff)')
     subparser.add_argument('-s', '--silent', action='store_true', help='don\'t report output and correct answer even if not AC  (for --mode all)')
     subparser.add_argument('-e', '--error', type=float, help='check as floating point number: correct if its absolute or relative error doesn\'t exceed it')
     subparser.add_argument('-t', '--tle', type=float, help='set the time limit (in second) (default: inf)')

--- a/onlinejudge_command/output_comparators.py
+++ b/onlinejudge_command/output_comparators.py
@@ -40,11 +40,11 @@ class FloatingPointNumberComparator(OutputComparator):
         :returns: True if the relative error or absolute error is smaller than the accepted error
         """
         try:
-            x: Optional[float] = float(actual)
+            x = float(actual)  # type: Optional[float]
         except ValueError:
             x = None
         try:
-            y: Optional[float] = float(actual)
+            y = float(actual)  # type: Optional[float]
         except ValueError:
             y = None
         if x is not None and y is not None:

--- a/onlinejudge_command/output_comparators.py
+++ b/onlinejudge_command/output_comparators.py
@@ -4,7 +4,6 @@
 import abc
 import math
 import pathlib
-import shlex
 import tempfile
 from logging import getLogger
 from typing import *
@@ -103,11 +102,12 @@ class SpecialJudge:
             with open(str(actual_output_path), 'wb') as fh:
                 fh.write(actual_output)
 
+            # if you use shlex.quote, it fails on Windows. why?
             command = ' '.join([
                 self.judge_command,  # already quoted and joined command
-                shlex.quote(str(input_path.resolve())),
-                shlex.quote(str(actual_output_path.resolve())),
-                shlex.quote(str(expected_output_path.resolve() if expected_output_path is not None else '')),
+                str(input_path.resolve()),
+                str(actual_output_path.resolve()),
+                str(expected_output_path.resolve() if expected_output_path is not None else ''),
             ])
 
             logger.info('$ %s', command)

--- a/onlinejudge_command/output_comparators.py
+++ b/onlinejudge_command/output_comparators.py
@@ -1,0 +1,117 @@
+"""This module collects helper classes to compare outputs for `test` subcommand.
+"""
+
+import abc
+import math
+import pathlib
+import shlex
+import tempfile
+from logging import getLogger
+from typing import *
+
+import onlinejudge_command.utils as utils
+
+logger = getLogger(__name__)
+
+
+class OutputComparator(abc.ABC):
+    @abc.abstractmethod
+    def __call__(self, actual: bytes, expected: bytes) -> bool:
+        """
+        :returns: True is the two are matched.
+        """
+        raise NotImplementedError
+
+
+class ExactComparator(OutputComparator):
+    def __call__(self, actual: bytes, expected: bytes) -> bool:
+        return actual == expected
+
+
+class FloatingPointNumberComparator(OutputComparator):
+    def __init__(self, *, rel_tol: float, abs_tol: float):
+        if max(rel_tol, abs_tol) > 1:
+            logger.warning('the tolerance is too large: relative = %s, absolute = %s', rel_tol, abs_tol)
+        self.rel_tol = rel_tol
+        self.abs_tol = abs_tol
+
+    def __call__(self, actual: bytes, expected: bytes) -> bool:
+        """
+        :returns: True if the relative error or absolute error is smaller than the accepted error
+        """
+        try:
+            x: Optional[float] = float(actual)
+        except ValueError:
+            x = None
+        try:
+            y: Optional[float] = float(actual)
+        except ValueError:
+            y = None
+        if x is not None and y is not None:
+            return math.isclose(x, y, rel_tol=self.rel_tol, abs_tol=self.abs_tol)
+        else:
+            return actual == expected
+
+
+class SplitComparator(OutputComparator):
+    def __init__(self, word_comparator: OutputComparator):
+        self.word_comparator = word_comparator
+
+    def __call__(self, actual: bytes, expected: bytes) -> bool:
+        # str.split() also removes trailing '\r'
+        actual_words = actual.split()
+        expected_words = expected.split()
+        if len(actual_words) != len(expected_words):
+            return False
+        for x, y in zip(actual_words, expected_words):
+            if not self.word_comparator(x, y):
+                return False
+        return True
+
+
+class SplitLinesComparator(OutputComparator):
+    def __init__(self, line_comparator: OutputComparator):
+        self.line_comparator = line_comparator
+
+    def __call__(self, actual: bytes, expected: bytes) -> bool:
+        actual_lines = actual.rstrip(b'\n').split(b'\n')
+        expected_lines = expected.rstrip(b'\n').split(b'\n')
+        if len(actual_lines) != len(expected_lines):
+            return False
+        for x, y in zip(actual_lines, expected_lines):
+            if not self.line_comparator(x, y):
+                return False
+        return True
+
+
+class CRLFInsensitiveComparator(OutputComparator):
+    def __init__(self, file_comparator: OutputComparator):
+        self.file_comparator = file_comparator
+
+    def __call__(self, actual: bytes, expected: bytes) -> bool:
+        return self.file_comparator(actual.replace(b'\r\n', b'\n'), expected.replace(b'\r\n', b'\n'))
+
+
+class SpecialJudge:
+    def __init__(self, judge_command: str, *, is_silent: bool):
+        self.judge_command = judge_command  # already quoted and joined command
+        self.is_silent = is_silent
+
+    def run(self, *, actual_output: bytes, input_path: pathlib.Path, expected_output_path: Optional[pathlib.Path]) -> bool:
+        with tempfile.TemporaryDirectory() as tempdir:
+            actual_output_path = pathlib.Path(tempdir) / 'actual.out'
+            with open(str(actual_output_path), 'wb') as fh:
+                fh.write(actual_output)
+
+            command = ' '.join([
+                self.judge_command,  # already quoted and joined command
+                shlex.quote(str(input_path.resolve())),
+                shlex.quote(str(actual_output_path.resolve())),
+                shlex.quote(str(expected_output_path.resolve() if expected_output_path is not None else '')),
+            ])
+
+            logger.info('$ %s', command)
+            info, proc = utils.exec_command(command)
+        if not self.is_silent:
+            logger.info(utils.NO_HEADER + 'judge\'s output:\n%s', utils.make_pretty_large_file_content(info['answer'] or b'', limit=40, head=20, tail=10, bold=True))
+        return proc.returncode == 0

--- a/onlinejudge_command/subcommand/test.py
+++ b/onlinejudge_command/subcommand/test.py
@@ -59,13 +59,13 @@ def compare_and_report(proc: subprocess.Popen, answer: str, memory: Optional[flo
         is_exact = False
         if compare_mode == CompareMode.EXACT_MATCH and error is None:
             is_exact = True
-            file_comparator: output_comparators.OutputComparator = output_comparators.ExactComparator()
+            file_comparator = output_comparators.ExactComparator()  # type: output_comparators.OutputComparator
         elif compare_mode == CompareMode.CRLF_INSENSITIVE_EXACT_MATCH and error is None:
             is_exact = True
             file_comparator = output_comparators.CRLFInsensitiveComparator(output_comparators.ExactComparator())
         else:
             if error is not None:
-                word_comparator: output_comparators.OutputComparator = output_comparators.FloatingPointNumberComparator(rel_tol=error, abs_tol=error)
+                word_comparator = output_comparators.FloatingPointNumberComparator(rel_tol=error, abs_tol=error)  # type: output_comparators.OutputComparator
             else:
                 word_comparator = output_comparators.ExactComparator()
             if compare_mode in (CompareMode.EXACT_MATCH, CompareMode.CRLF_INSENSITIVE_EXACT_MATCH, CompareMode.IGNORE_SPACES):

--- a/onlinejudge_command/subcommand/test.py
+++ b/onlinejudge_command/subcommand/test.py
@@ -2,9 +2,9 @@
 import collections
 import concurrent.futures
 import contextlib
+import enum
 import itertools
 import json
-import math
 import os
 import pathlib
 import re
@@ -19,6 +19,7 @@ from typing import *
 
 import diff_match_patch
 import onlinejudge_command.format_utils as fmtutils
+import onlinejudge_command.output_comparators as output_comparators
 import onlinejudge_command.utils as utils
 
 if TYPE_CHECKING:
@@ -30,87 +31,58 @@ MEMORY_WARNING = 500  # megabyte
 MEMORY_PRINT = 100  # megabyte
 
 
-def compare_as_floats(xs_: str, ys_: str, error: float) -> bool:
-    def f(x):
-        try:
-            y = float(x)
-            if not math.isfinite(y):
-                logger.warning('not an real number found: %f', y)
-            return y
-        except ValueError:
-            return x
-
-    xs = list(map(f, xs_.split()))
-    ys = list(map(f, ys_.split()))
-    if len(xs) != len(ys):
-        return False
-    for x, y in zip(xs, ys):
-        if isinstance(x, float) and isinstance(y, float):
-            if not math.isclose(x, y, rel_tol=error, abs_tol=error):
-                return False
-        else:
-            if x != y:
-                return False
-    return True
+class CompareMode(enum.Enum):
+    EXACT_MATCH = 'exact-match'
+    CRLF_INSENSITIVE_EXACT_MATCH = 'crlf-insensitive-exact-match'
+    IGNORE_SPACES = 'ignore-spaces'
+    IGNORE_SPACES_AND_NEWLINES = 'ignore-spaces-and-newlines'
 
 
-def compare_and_report(proc: subprocess.Popen, answer: str, memory: Optional[float], test_input_path: pathlib.Path, test_output_path: Optional[pathlib.Path], *, mle: Optional[float], mode: str, error: Optional[float], does_print_input: bool, silent: bool, rstrip: bool, judge: Optional[str]) -> str:
-    rstrip_targets = ' \t\r\n\f\v\0'  # ruby's one, follow AnarchyGolf
+class DisplayMode(enum.Enum):
+    SUMMARY = 'summary'
+    DIFF = 'diff'
 
+
+def compare_and_report(proc: subprocess.Popen, answer: str, memory: Optional[float], test_input_path: pathlib.Path, test_output_path: Optional[pathlib.Path], *, mle: Optional[float], display_mode: DisplayMode, error: Optional[float], does_print_input: bool, silent: bool, compare_mode: CompareMode, judge_command: Optional[str]) -> str:
     # prepare the comparing function
-    if error is not None:  # float mode
-        match = lambda a, b: compare_as_floats(a, b, error)
-    elif judge is not None:  # special judge mode
+    if judge_command is not None:
+        special_judge = output_comparators.SpecialJudge(judge_command=judge_command, is_silent=silent)
 
-        def match(a: str, b: str) -> bool:
-            # On Windows, a temp file is not created if we use "with" statement,
-            user_output = tempfile.NamedTemporaryFile(delete=False)
-            judge_result = False
-            try:
-                if rstrip:
-                    user_output.write(a.rstrip(rstrip_targets).encode())
-                else:
-                    user_output.write(a.encode())
-                user_output.close()
-
-                arg0 = judge
-                arg1 = str(test_input_path.resolve())
-                arg2 = user_output.name
-                arg3 = str((str(test_output_path.resolve()) if test_output_path is not None else ''))
-
-                actual_command = '{} {} {} {}'.format(arg0, arg1, arg2, arg3)  # TODO: quote arguments for paths including spaces; see https://github.com/kmyk/online-judge-tools/pull/584
-                logger.info('$ %s', actual_command)
-                info, proc = utils.exec_command(actual_command)
-                if not silent:
-                    logger.info(utils.NO_HEADER + 'judge\'s output:\n%s', utils.make_pretty_large_file_content(info['answer'] or b'', limit=40, head=20, tail=10, bold=True))
-                judge_result = (proc.returncode == 0)
-            finally:
-                os.unlink(user_output.name)
-            return judge_result
+        def match(actual: bytes, expected: bytes) -> bool:
+            # the second argument is ignored
+            return special_judge.run(
+                actual_output=actual,
+                input_path=test_input_path,
+                expected_output_path=test_output_path,
+            )
     else:
+        is_exact = False
+        if compare_mode == CompareMode.EXACT_MATCH and error is None:
+            is_exact = True
+            file_comparator: output_comparators.OutputComparator = output_comparators.ExactComparator()
+        elif compare_mode == CompareMode.CRLF_INSENSITIVE_EXACT_MATCH and error is None:
+            is_exact = True
+            file_comparator = output_comparators.CRLFInsensitiveComparator(output_comparators.ExactComparator())
+        else:
+            if error is not None:
+                word_comparator: output_comparators.OutputComparator = output_comparators.FloatingPointNumberComparator(rel_tol=error, abs_tol=error)
+            else:
+                word_comparator = output_comparators.ExactComparator()
+            if compare_mode in (CompareMode.EXACT_MATCH, CompareMode.CRLF_INSENSITIVE_EXACT_MATCH, CompareMode.IGNORE_SPACES):
+                file_comparator = output_comparators.SplitLinesComparator(output_comparators.SplitComparator(word_comparator))
+            elif compare_mode == CompareMode.IGNORE_SPACES_AND_NEWLINES:
+                file_comparator = output_comparators.SplitComparator(word_comparator)
+            else:
+                assert False
+            file_comparator = output_comparators.CRLFInsensitiveComparator(file_comparator)
 
-        def match(a: str, b: str) -> bool:
-            if a == b:
-                return True
-            if rstrip and a.rstrip(rstrip_targets) == b.rstrip(rstrip_targets):
-                logger.warning('WA if no rstrip')
-                return True
-            if a == b.replace('\n', '\r\n'):
-                logger.warning(r'WA if not replacing "\r\n" with "\n"')
-                return True
-            if rstrip and a.rstrip(rstrip_targets) == b.replace('\n', '\r\n').rstrip(rstrip_targets):
-                logger.warning('WA if no rstrip')
-                logger.warning(r'WA if not replacing "\r\n" with "\n"')
-                return True
-            if a.replace('\n', '\r\n') == b:
-                logger.warning(r'WA if not replacing "\n" with "\r\n"')
-                return True
-            if rstrip and a.replace('\n', '\r\n').rstrip(rstrip_targets) == b.rstrip(rstrip_targets):
-                # TODO: use a smart way if you need more equality patterns
-                logger.warning('WA if no rstrip')
-                logger.warning(r'WA if not replacing "\n" with "\r\n"')
-                return True
-            return False
+        def match(actual: bytes, expected: bytes) -> bool:
+            result = file_comparator(actual, expected)
+            if not result and is_exact:
+                non_stcict_comparator = output_comparators.CRLFInsensitiveComparator(output_comparators.SplitComparator(output_comparators.ExactComparator()))
+                if non_stcict_comparator(actual, expected):
+                    logger.warning('This was AC if spaces and newlines were ignored. Please use --ignore-spaces (-S) option or --ignore-spaces-and-newline (-N) option.')
+            return result
 
     # prepare the function to print the input
     is_input_printed = False
@@ -138,22 +110,22 @@ def compare_and_report(proc: subprocess.Popen, answer: str, memory: Optional[flo
         print_input()
 
     # check WA or not
-    if (test_output_path is not None) or (judge is not None):
+    if (test_output_path is not None) or (judge_command is not None):
         if test_output_path is not None:
             with test_output_path.open('rb') as outf:
                 expected = outf.read().decode()
-        else:  # only if --judge-command option
+        else:  # only if --judge option
             expected = ''
             logger.warning('expected output is not found')
         # compare
-        if not match(answer, expected):
+        if not match(answer.encode(), expected.encode()):
             logger.info(utils.FAILURE + '' + utils.red('WA'))
             print_input()
             if not silent:
-                if mode == 'simple':
+                if display_mode == DisplayMode.SUMMARY:
                     logger.info(utils.NO_HEADER + 'output:\n%s', utils.make_pretty_large_file_content(answer.encode(), limit=40, head=20, tail=10, bold=True))
                     logger.info(utils.NO_HEADER + 'expected:\n%s', utils.make_pretty_large_file_content(expected.encode(), limit=40, head=20, tail=10, bold=True))
-                elif mode == 'side-by-side':
+                elif display_mode == DisplayMode.DIFF:
                     if max(answer.count('\n'), expected.count('\n')) <= 40:
                         display_side_by_side_color(answer, expected)
                     else:
@@ -201,7 +173,7 @@ def test_single_case(test_name: str, test_input_path: pathlib.Path, test_output_
             else:
                 logger.warning('memory: %f MB', memory)
 
-        status = compare_and_report(proc, answer, memory, test_input_path, test_output_path, mle=args.mle, mode=args.display_mode, error=args.error, does_print_input=args.print_input, silent=args.silent, rstrip=args.rstrip, judge=args.judge)
+        status = compare_and_report(proc, answer, memory, test_input_path, test_output_path, mle=args.mle, display_mode=DisplayMode(args.display_mode), error=args.error, does_print_input=args.print_input, silent=args.silent, compare_mode=CompareMode(args.compare_mode), judge_command=args.judge)
 
     # return the result
     testcase = {

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -59,11 +59,95 @@ class TestTest(unittest.TestCase):
                 },
                 {
                     'path': 'test/sample-3.in',
-                    'data': 'foobar \n'
+                    'data': 'foo  bar \n'
                 },
                 {
                     'path': 'test/sample-3.out',
-                    'data': 'foobar\n'
+                    'data': 'foo bar\n'
+                },
+                {
+                    'path': 'test/sample-4.in',
+                    'data': 'foo \n bar \n'
+                },
+                {
+                    'path': 'test/sample-4.out',
+                    'data': 'foo bar\n'
+                },
+            ],
+            expected=[{
+                'status': 'AC',
+                'testcase': {
+                    'name': 'sample-1',
+                    'input': '%s/test/sample-1.in',
+                    'output': '%s/test/sample-1.out',
+                },
+                'output': 'foo\n',
+                'exitcode': 0,
+            }, {
+                'status': 'WA',
+                'testcase': {
+                    'name': 'sample-2',
+                    'input': '%s/test/sample-2.in',
+                    'output': '%s/test/sample-2.out',
+                },
+                'output': 'bar\n',
+                'exitcode': 0,
+            }, {
+                'status': 'WA',
+                'testcase': {
+                    'name': 'sample-3',
+                    'input': '%s/test/sample-3.in',
+                    'output': '%s/test/sample-3.out',
+                },
+                'output': 'foo  bar \n',
+                'exitcode': 0,
+            }, {
+                'status': 'WA',
+                'testcase': {
+                    'name': 'sample-4',
+                    'input': '%s/test/sample-4.in',
+                    'output': '%s/test/sample-4.out',
+                },
+                'output': 'foo \n bar \n',
+                'exitcode': 0,
+            }],
+        )
+
+    def test_call_test_simple_with_ignore_spaces(self):
+        self.snippet_call_test(
+            args=['-c', cat(), '--compare-mode', 'ignore-spaces'],
+            files=[
+                {
+                    'path': 'test/sample-1.in',
+                    'data': 'foo\n'
+                },
+                {
+                    'path': 'test/sample-1.out',
+                    'data': 'foo\n'
+                },
+                {
+                    'path': 'test/sample-2.in',
+                    'data': 'bar\n'
+                },
+                {
+                    'path': 'test/sample-2.out',
+                    'data': 'foo\n'
+                },
+                {
+                    'path': 'test/sample-3.in',
+                    'data': 'foo  bar \n'
+                },
+                {
+                    'path': 'test/sample-3.out',
+                    'data': 'foo bar\n'
+                },
+                {
+                    'path': 'test/sample-4.in',
+                    'data': 'foo \n bar \n'
+                },
+                {
+                    'path': 'test/sample-4.out',
+                    'data': 'foo bar\n'
                 },
             ],
             expected=[{
@@ -91,32 +175,92 @@ class TestTest(unittest.TestCase):
                     'input': '%s/test/sample-3.in',
                     'output': '%s/test/sample-3.out',
                 },
-                'output': 'foobar \n',
+                'output': 'foo  bar \n',
+                'exitcode': 0,
+            }, {
+                'status': 'WA',
+                'testcase': {
+                    'name': 'sample-4',
+                    'input': '%s/test/sample-4.in',
+                    'output': '%s/test/sample-4.out',
+                },
+                'output': 'foo \n bar \n',
                 'exitcode': 0,
             }],
         )
 
-    def test_call_test_norstrip(self):
+    def test_call_test_simple_with_ignore_spaces_and_newlines(self):
         self.snippet_call_test(
-            args=['-c', cat(), '--no-rstrip'],
+            args=['-c', cat(), '--compare-mode', 'ignore-spaces-and-newlines'],
             files=[
                 {
                     'path': 'test/sample-1.in',
-                    'data': 'foo \n'
+                    'data': 'foo\n'
                 },
                 {
                     'path': 'test/sample-1.out',
                     'data': 'foo\n'
                 },
+                {
+                    'path': 'test/sample-2.in',
+                    'data': 'bar\n'
+                },
+                {
+                    'path': 'test/sample-2.out',
+                    'data': 'foo\n'
+                },
+                {
+                    'path': 'test/sample-3.in',
+                    'data': 'foo  bar \n'
+                },
+                {
+                    'path': 'test/sample-3.out',
+                    'data': 'foo bar\n'
+                },
+                {
+                    'path': 'test/sample-4.in',
+                    'data': 'foo \n bar \n'
+                },
+                {
+                    'path': 'test/sample-4.out',
+                    'data': 'foo bar\n'
+                },
             ],
             expected=[{
-                'status': 'WA',
+                'status': 'AC',
                 'testcase': {
                     'name': 'sample-1',
                     'input': '%s/test/sample-1.in',
                     'output': '%s/test/sample-1.out',
                 },
-                'output': 'foo \n',
+                'output': 'foo\n',
+                'exitcode': 0,
+            }, {
+                'status': 'WA',
+                'testcase': {
+                    'name': 'sample-2',
+                    'input': '%s/test/sample-2.in',
+                    'output': '%s/test/sample-2.out',
+                },
+                'output': 'bar\n',
+                'exitcode': 0,
+            }, {
+                'status': 'AC',
+                'testcase': {
+                    'name': 'sample-3',
+                    'input': '%s/test/sample-3.in',
+                    'output': '%s/test/sample-3.out',
+                },
+                'output': 'foo  bar \n',
+                'exitcode': 0,
+            }, {
+                'status': 'AC',
+                'testcase': {
+                    'name': 'sample-4',
+                    'input': '%s/test/sample-4.in',
+                    'output': '%s/test/sample-4.out',
+                },
+                'output': 'foo \n bar \n',
                 'exitcode': 0,
             }],
         )
@@ -143,11 +287,11 @@ class TestTest(unittest.TestCase):
                 },
                 {
                     'path': 'test/sample-3.in',
-                    'data': 'foo\n'
+                    'data': 'foo 3.01\n'
                 },
                 {
                     'path': 'test/sample-3.out',
-                    'data': 'foo\n'
+                    'data': 'foo 3.02\n'
                 },
                 {
                     'path': 'test/sample-4.in',
@@ -176,7 +320,7 @@ class TestTest(unittest.TestCase):
                 'output': '1.0\n',
                 'exitcode': 0,
             }, {
-                'status': 'WA',
+                'status': 'AC',
                 'testcase': {
                     'name': 'sample-2',
                     'input': '%s/test/sample-2.in',
@@ -191,7 +335,7 @@ class TestTest(unittest.TestCase):
                     'input': '%s/test/sample-3.in',
                     'output': '%s/test/sample-3.out',
                 },
-                'output': 'foo\n',
+                'output': 'foo 3.01\n',
                 'exitcode': 0,
             }, {
                 'status': 'WA',
@@ -282,9 +426,9 @@ class TestTest(unittest.TestCase):
             }],
         )
 
-    def test_call_test_multiline_all(self):
+    def test_call_test_multiline(self):
         self.snippet_call_test(
-            args=['-c', cat(), '-m', 'simple'],
+            args=['-c', cat()],
             files=[
                 {
                     'path': 'test/sample-1.in',
@@ -324,9 +468,9 @@ class TestTest(unittest.TestCase):
             }],
         )
 
-    def test_call_test_multiline_line(self):
+    def test_call_test_multiline_with_display_mode_diff(self):
         self.snippet_call_test(
-            args=['-c', cat(), '-m', 'side-by-side'],
+            args=['-c', cat(), '--display-mode', 'diff'],
             files=[
                 {
                     'path': 'test/sample-1.in',
@@ -965,7 +1109,7 @@ class TestTest(unittest.TestCase):
             replace_output_newline=False,
         )
 
-    def test_call_expected_uses_crlf(self):
+    def test_call_expected_uses_crlf_with_default_mode(self):
         data = self.snippet_call_test(
             args=['-c', tests.utils.python_c(r"import sys; sys.stdout.buffer.write(b'foo\nbar\nbaz\n')")],
             files=[
@@ -991,9 +1135,61 @@ class TestTest(unittest.TestCase):
             replace_output_newline=False,
         )
 
-    def test_call_output_uses_both_lf_and_crlf(self):
+    def test_call_expected_uses_crlf_with_exact_match(self):
+        data = self.snippet_call_test(
+            args=['-c', tests.utils.python_c(r"import sys; sys.stdout.buffer.write(b'foo\nbar\nbaz\n')"), '--compare-mode', 'exact-match'],
+            files=[
+                {
+                    'path': 'test/sample-1.in',
+                    'data': '',
+                },
+                {
+                    'path': 'test/sample-1.out',
+                    'data': 'foo\r\nbar\r\nbaz\r\n',
+                },
+            ],
+            expected=[{
+                'status': 'WA',
+                'testcase': {
+                    'name': 'sample-1',
+                    'input': '%s/test/sample-1.in',
+                    'output': '%s/test/sample-1.out',
+                },
+                'output': 'foo\nbar\nbaz\n',
+                'exitcode': 0,
+            }],
+            replace_output_newline=False,
+        )
+
+    def test_call_output_uses_both_lf_and_crlf_with_default_mode(self):
         data = self.snippet_call_test(
             args=['-c', tests.utils.python_c(r"import sys; sys.stdout.buffer.write(b'foo\r\nbar\nbaz\r\n')")],
+            files=[
+                {
+                    'path': 'test/sample-1.in',
+                    'data': '',
+                },
+                {
+                    'path': 'test/sample-1.out',
+                    'data': 'foo\nbar\nbaz\n'
+                },
+            ],
+            expected=[{
+                'status': 'AC',
+                'testcase': {
+                    'name': 'sample-1',
+                    'input': '%s/test/sample-1.in',
+                    'output': '%s/test/sample-1.out',
+                },
+                'output': 'foo\r\nbar\nbaz\r\n',
+                'exitcode': 0,
+            }],
+            replace_output_newline=False,
+        )
+
+    def test_call_output_uses_both_lf_and_crlf_with_exact_match(self):
+        data = self.snippet_call_test(
+            args=['-c', tests.utils.python_c(r"import sys; sys.stdout.buffer.write(b'foo\r\nbar\nbaz\r\n')"), '--compare-mode', 'exact-match'],
             files=[
                 {
                     'path': 'test/sample-1.in',


### PR DESCRIPTION
close https://github.com/online-judge-tools/oj/issues/774 https://github.com/online-judge-tools/oj/issues/810
related https://github.com/online-judge-tools/oj/issues/776

For the `test` subcommand,

-   the default behavior of comparing is updated
-   options are updated
    -   rename `-m` option to `-M` option
    -   rename `--side-by-side` `-S` option to `--diff` `-D` option
    -   remove `--rstrip` `--no-rstrip` options
    -   add `--compare-mode` `--ignore-spaces` `--ignore-spaces-and-newlines` options
    -   add `--display-mode` option