### PR TITLE
For `test` subcommand, use `.\a.exe` instead of `./a.out` for the default command on Windows

### DIFF
--- a/onlinejudge_command/main.py
+++ b/onlinejudge_command/main.py
@@ -125,7 +125,7 @@ tips:
   You can do similar things with shell
     e.g. $ for f in test/*.in ; do echo $f ; ./a.out < $f | diff - ${f%.in}.out ; done
 ''')
-    subparser.add_argument('-c', '--command', default='./a.out', help='your solution to be tested. (default: "./a.out")')
+    subparser.add_argument('-c', '--command', default=utils.get_default_command(), help='your solution to be tested. (default: "{}")'.format(utils.get_default_command()))
     subparser.add_argument('-f', '--format', default='%s.%e', help='a format string to recognize the relationship of test cases. (default: "%%s.%%e")')
     subparser.add_argument('-d', '--directory', type=pathlib.Path, default=pathlib.Path('test'), help='a directory name for test cases (default: test/)')
     subparser.add_argument('-m', '--compare-mode', choices=[mode.value for mode in CompareMode], default=CompareMode.CRLF_INSENSITIVE_EXACT_MATCH.value, help='mode to compare outputs. The default behavoir is exact-match to ensure that you always get AC on remote judge servers when you got AC on local tests for the same cases.  (default: crlf-insensitive-exact-match)')
@@ -159,7 +159,7 @@ tips:
   You can do similar things with shell
     e.g. $ for f in test/*.in ; do ./a.out < $f > ${f%.in}.out ; done
 ''')
-    subparser.add_argument('-c', '--command', default='./a.out', help='your solution to be tested. (default: "./a.out")')
+    subparser.add_argument('-c', '--command', default=utils.get_default_command(), help='your solution to be tested. (default: "{}")'.format(utils.get_default_command()))
     subparser.add_argument('-f', '--format', default='%s.%e', help='a format string to recognize the relationship of test cases. (default: "%%s.%%e")')
     subparser.add_argument('-d', '--directory', type=pathlib.Path, default=pathlib.Path('test'), help='a directory name for test cases (default: test/)')
     subparser.add_argument('-t', '--tle', type=float, help='set the time limit (in second) (default: inf)')
@@ -196,7 +196,7 @@ tips:
   You can do similar things with shell
     e.g. $ mkfifo a.pipe && ./a.out < a.pipe | python3 judge.py > a.pipe
 ''')
-    subparser.add_argument('-c', '--command', default='./a.out', help='your solution to be tested. (default: "./a.out")')
+    subparser.add_argument('-c', '--command', default=utils.get_default_command(), help='your solution to be tested. (default: "{}")'.format(utils.get_default_command()))
     subparser.add_argument('judge', help='judge program using standard I/O')
 
     return parser

--- a/onlinejudge_command/utils.py
+++ b/onlinejudge_command/utils.py
@@ -188,3 +188,13 @@ def webbrowser_register_explorer_exe() -> None:
         return
     instance = webbrowser.GenericBrowser('explorer.exe')
     webbrowser.register('explorer', None, instance)  # TODO: use `preferred=True` to solve the issue that terminal is cleared, when the version of Python becomes 3.7 or higher
+
+
+def get_default_command() -> str:
+    """get_default_command returns a command to execute the default output of g++ or clang++. The value is basically `./a.out`, but `.\a.exe` on Windows.
+
+    The type of return values must be `str` and must not be `pathlib.Path`, because the strings `./a.out` and `a.out` are different as commands but same as a path.
+    """
+    if platform.system() == 'Windows':
+        return r'.\a.exe'
+    return './a.out'


### PR DESCRIPTION
わりと以下のような混乱が生じてるぽいので、破壊的変更ついでに

<blockquote class="twitter-tweet" data-partner="tweetdeck"><p lang="ja" dir="ltr">online-judge-toolsをコマンドプロンプトを使って実行しようとしました。しかし、警告やエラーが起きて正常に実行出来なかったのですが、どのように改善すれば良いでしょうか？<a href="https://twitter.com/hashtag/%E7%AB%B6%E3%83%97%E3%83%AD?src=hash&amp;ref_src=twsrc%5Etfw">#競プロ</a> <a href="https://twitter.com/hashtag/AtCoder?src=hash&amp;ref_src=twsrc%5Etfw">#AtCoder</a> <a href="https://t.co/tuQ0aTvBZd">pic.twitter.com/tuQ0aTvBZd</a></p>&mdash; Leo (@Leo80417411) <a href="https://twitter.com/Leo80417411/status/1303232798719791104?ref_src=twsrc%5Etfw">September 8, 2020</a></blockquote>