### PR TITLE
Fix the old link in the help text

### DIFF
--- a/onlinejudge_command/main.py
+++ b/onlinejudge_command/main.py
@@ -134,7 +134,7 @@ format string for --format:
   (both %s and %e are required.)
 
 tips:
-  There is a feature to use special judges. See https://online-judge-tools.readthedocs.io/en/master/introduction.en.html#test-for-problems-with-special-judge for details.
+  There is a feature to use special judges. See https://github.com/online-judge-tools/oj/blob/master/docs/getting-started.md for details.
 
   You can do similar things with shell
     e.g. $ for f in test/*.in ; do echo $f ; ./a.out < $f | diff - ${f%.in}.out ; done


### PR DESCRIPTION
Hi, this is a tiny fix of the old read-the-docs link in the help text.

Thank you for creating a useful tool! 🙂 