### PR TITLE
Use $YUKICODER_TOKEN and $DROPBOX_TOKEN envvar for a security reason

### DIFF
--- a/onlinejudge_command/subcommand/download.py
+++ b/onlinejudge_command/subcommand/download.py
@@ -65,8 +65,8 @@ tips:
     subparser.add_argument('-n', '--dry-run', action='store_true', help='don\'t write to files')
     subparser.add_argument('-a', '--system', action='store_true', help='download system testcases')
     subparser.add_argument('-s', '--silent', action='store_true')
-    subparser.add_argument('--yukicoder-token', type=str)
-    subparser.add_argument('--dropbox-token', type=str)
+    subparser.add_argument('--yukicoder-token', type=str, default=os.environ.get('YUKICODER_TOKEN'), help='[deprecated] specify the token of yukicoder. For a security reason, use the $YUKICODER_TOKEN envvar. (default: $YUKICODER_TOKEN)')
+    subparser.add_argument('--dropbox-token', type=str, default=os.environ.get('DROPBOX_TOKEN'), help='[deprecated] specify the token of dropbox. For a security reason, use the $DROPBOX_TOKEN envvar. (default: $DROPBOX_TOKEN)')
     subparser.add_argument('--log-file', type=pathlib.Path, help=argparse.SUPPRESS)
 
 


### PR DESCRIPTION
#672 

> verify helper から yukicoder が利用できるとうれしいので対応したい。 実装は単に `--yukicoder-token` みたいなオプションを用意するのがよさそう。`YUKICODER_TOKEN` みたいな環境変数を設定させてそれを読むのは一般には自然だが、現状の online-judge-tools は他にはまったく環境変数を見ないので一貫性が損われる。

導入時は上記のような経緯でコマンドライン引数として実装されていました。

https://github.com/online-judge-tools/api-client/blob/78203fe3a71d165674301a8a4718a36867af4f18/onlinejudge_api/main.py#L55

しかし、その後に api-client ではセキュリティ的に良くないとコマンドライン引数は廃止されています。

全廃すると影響が多大なので「使えるようにはしているけど推奨はしない」くらいの扱いにしておくのが良いのではないかと思います。