### PR TITLE
Fortran 2008への対応

### DIFF
--- a/onlinejudge_command/subcommand/submit.py
+++ b/onlinejudge_command/subcommand/submit.py
@@ -392,7 +392,7 @@ def guess_lang_ids_of_file(filename: pathlib.Path, code: bytes, language_dict, c
              { 'names': [ 'crystal'               ], 'exts': [ 'cr'        ] },
              { 'names': [ 'd'                     ], 'exts': [ 'd'         ], 'split': True },
              { 'names': [ 'f#'                    ], 'exts': [ 'fs'        ] },
-             { 'names': [ 'fortran'               ], 'exts': [ 'for', 'f', 'f90', 'f95', 'f03' ] },
+             { 'names': [ 'fortran'               ], 'exts': [ 'for', 'f', 'f90', 'f95', 'f03', 'f08' ] },
              { 'names': [ 'go'                    ], 'exts': [ 'go'        ], 'split': True },
              { 'names': [ 'haskell'               ], 'exts': [ 'hs'        ] },
              { 'names': [ 'java'                  ], 'exts': [ 'java'      ] },


### PR DESCRIPTION
ojの実装上Fortran 2008のコードをFortranだと認識できないようになっていたのでFortran 2008の拡張子である"f08"を追加しました.  
AtCoderではFortran 2008が使用されておりFortranの中でもメジャーなバージョンだと認識しています.  
https://atcoder.jp/contests/abc161/rules
