### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
+        include:
+          - os: ubuntu-20.04
+            python-version: 3.6
+        exclude:
+          - os: ubuntu-latest
+            python-version: 3.6
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
ubuntu-latest が示すバージョンが 20.04 から 22.04 に更新された関係で、CI が落ちるようになっていた問題を修正しました。

この問題の原因は ubuntu 22.04 にて python 3.6 がサポートされなくなったことでした。そのため、ubuntu で python 3.6 のテストを行う際のみ、os を `ubuntu-20.04` にすることでこの問題を解決しました。
